### PR TITLE
reinstated log output only for debug level.

### DIFF
--- a/src/main/java/org/ggt/kafka/config/provider/KafkaEnvConfigProvider.java
+++ b/src/main/java/org/ggt/kafka/config/provider/KafkaEnvConfigProvider.java
@@ -25,6 +25,7 @@ public class KafkaEnvConfigProvider implements ConfigProvider {
   public ConfigData get(String path) {
     LOGGER.debug("get(path) method invoked [path={}] ...", path);
     ConfigData configData = new ConfigData(propertiesProvider.getProperties());
+    LOGGER.debug("returning ConfigData [data={}, ttl={}]", configData.data(), configData.ttl());
 
     return configData;
   }
@@ -33,6 +34,7 @@ public class KafkaEnvConfigProvider implements ConfigProvider {
   public ConfigData get(String path, Set<String> keys) {
     LOGGER.info("get(path, keys) method invoked [path={}, keys={}]", path, keys);
     ConfigData configData = new ConfigData(propertiesProvider.getProperties(keys));
+    LOGGER.debug("returning ConfigData [data={}, ttl={}]", configData.data(), configData.ttl());
 
     return configData;
   }


### PR DESCRIPTION
I think this is a better solution as it can be controlled via the log4j logging level which is currently configured in the connect container to be INFO.